### PR TITLE
feat: add synthetic data generator, CLI, and contract tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Game Launch Budget Optimization - Makefile
 # A handy build automation tool to make setup, running, and testing easier!
-# Activates .venv and defines setup, baseline, test targets
+# Activates venv and defines setup, baseline, test targets
 
 .PHONY: help setup test baseline clean lint format check-venv
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Game Launch Marketing Budget Optimization
 
+![CI](https://github.com/christiancthomas/game-launch-budget-optimization/actions/workflows/pr-check.yml/badge.svg) ![Python](https://img.shields.io/badge/python-3.13%2B-blue)
+
 ## Problem summary
 
 Game launches often involve a flurry of marketing activity across multiple

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,66 @@
+"""CLI for budget optimization commands."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.config.load import load_config
+from src.data.synth import generate_channel_benchmarks, write_benchmarks_csv
+
+
+def cmd_synth(args):
+    """Generate synthetic channel benchmarks."""
+    config = load_config(args.config)
+
+    print("🎯 Generating synthetic channel benchmarks...")
+    benchmarks = generate_channel_benchmarks(config)
+
+    # Create output directory if needed
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    write_benchmarks_csv(benchmarks, str(output_path))
+
+    print(f"✅ Generated {len(benchmarks)} channel benchmarks")
+    print(f"📄 Saved to: {output_path}")
+
+    # Quick summary
+    for bench in benchmarks:
+        roi_at_max = bench["curve_a"] - 2 * bench["curve_b"] * bench["max_spend"]
+        print(
+            f"   {bench['channel']}: max_spend=${bench['max_spend']:.0f}, \
+                ROI@max={roi_at_max:.4f}"
+        )
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(description="Budget optimization tools")
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Synth command
+    synth_parser = subparsers.add_parser("synth", help="Generate synthetic data")
+    synth_parser.add_argument(
+        "--config", default="src/config/default.yaml", help="Path to config file"
+    )
+    synth_parser.add_argument(
+        "--output", default="data/raw/channel_benchmarks.csv", help="Output CSV path"
+    )
+    synth_parser.set_defaults(func=cmd_synth)
+
+    # Parse and execute
+    args = parser.parse_args()
+
+    if not hasattr(args, "func"):
+        parser.print_help()
+        sys.exit(1)
+
+    try:
+        args.func(args)
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli.py
+++ b/src/cli.py
@@ -16,7 +16,7 @@ def cmd_synth(args):
     benchmarks = generate_channel_benchmarks(config)
 
     # Create output directory if needed
-    output_path = Path(args.output)
+    output_path = Path(args.out)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     write_benchmarks_csv(benchmarks, str(output_path))
@@ -44,7 +44,7 @@ def main():
         "--config", default="src/config/default.yaml", help="Path to config file"
     )
     synth_parser.add_argument(
-        "--output", default="data/raw/channel_benchmarks.csv", help="Output CSV path"
+        "--out", default="data/raw/channel_benchmarks.csv", help="Output CSV path"
     )
     synth_parser.set_defaults(func=cmd_synth)
 

--- a/src/config/default.yaml
+++ b/src/config/default.yaml
@@ -10,23 +10,23 @@ horizon_days: 30  # Campaign duration
 
 # Marketing channels with their constraints
 channels:
-  - name: "Google"
+  - name: "google"
     min_spend: 5000.0     # Minimum spend required ($)
     max_spend: 40000.0    # Maximum spend allowed ($)
 
-  - name: "Meta"
+  - name: "meta"
     min_spend: 3000.0
     max_spend: 35000.0
 
-  - name: "TikTok"
+  - name: "tiktok"
     min_spend: 8000.0
     max_spend: 50000.0
 
-  - name: "Reddit"
+  - name: "reddit"
     min_spend: 2000.0
     max_spend: 25000.0
 
-  - name: "X"
+  - name: "x"
     min_spend: 1000.0
     max_spend: 15000.0
 

--- a/src/data/synth.py
+++ b/src/data/synth.py
@@ -1,0 +1,130 @@
+"""Synthetic channel data for budget optimization.
+
+Models diminishing returns with quadratic curves. Generates realistic CPC/CTR/CVR
+metrics per channel, ignoring seasonality and genre effects for simplicity.
+"""
+
+import csv
+import random
+
+# Channel profiles with realistic characteristics for synthetic data generation
+CHANNEL_PROFILES = {
+    "google": {
+        "cpc_multiplier": 1.0,  # baseline
+        "ctr_multiplier": 1.2,  # high engagement
+        "cvr_multiplier": 1.5,  # strong conversion
+        "saturation_rate": 0.3,  # moderate saturation
+    },
+    "meta": {
+        "cpc_multiplier": 1.0,  # baseline
+        "ctr_multiplier": 0.9,  # high engagement
+        "cvr_multiplier": 1.1,  # strong conversion
+        "saturation_rate": 0.15,  # slow saturation
+    },
+    "tiktok": {
+        "cpc_multiplier": 0.6,  # cheap clicks
+        "ctr_multiplier": 1.3,  # high engagement
+        "cvr_multiplier": 0.7,  # moderate conversion
+        "saturation_rate": 0.2,  # slow saturation
+    },
+    "reddit": {
+        "cpc_multiplier": 0.8,  # cheap clicks
+        "ctr_multiplier": 1.1,  # high engagement
+        "cvr_multiplier": 1.0,  # moderate conversion
+        "saturation_rate": 0.4,  # faster saturation
+    },
+    "x": {
+        "cpc_multiplier": 0.6,  # cheap clicks
+        "ctr_multiplier": 1.0,  # moderate engagement
+        "cvr_multiplier": 0.5,  # low conversion
+        "saturation_rate": 0.6,  # faster saturation
+    },
+}
+
+
+def sample_base_metrics(config: dict):
+    """Random metrics from config ranges."""
+    synth = config["synth_data"]
+    return {
+        "cpc": random.uniform(*synth["cpc_range"]),
+        "ctr": random.uniform(*synth["ctr_range"]),
+        "cvr": random.uniform(*synth["cvr_range"]),
+    }
+
+
+def channel_adjustments(base_metrics: dict, channel_name: str):
+    """Apply channel personality multipliers."""
+
+    # Get the personality profile for this channel
+    profile = CHANNEL_PROFILES.get(channel_name.lower(), {})
+
+    # Apply multipliers to base metrics
+    return {
+        "cpc": base_metrics["cpc"] * profile.get("cpc_multiplier", 1.0),
+        "ctr": base_metrics["ctr"] * profile.get("ctr_multiplier", 1.0),
+        "cvr": base_metrics["cvr"] * profile.get("cvr_multiplier", 1.0),
+    }
+
+
+def sample_channel_metrics_for_channel(channel_name: str, config: dict):
+    """Sample metrics with channel personality."""
+
+    # Start with random base metrics
+    base = sample_base_metrics(config)
+
+    # Apply this channel's personality
+    return channel_adjustments(base, channel_name)
+
+
+def derive_quad_params(cpc: float, ctr: float, cvr: float, max_spend: float):
+    """Turn funnel metrics into (a,b) curve coefficients."""
+
+    # Key mathematical principle: conversions = a × spend - b × spend²
+    a = (ctr * cvr) / cpc  # this is our base efficiency, or performance at low spend
+
+    # We want the curve to slow down as we approach max_spend
+    # Let's say at max_spend, efficiency should drop by some target percentage
+    target_eff_drop = 0.3  # 30% efficiency loss at max spend
+    # - placeholder value, may end up adjusting
+
+    # Solve: efficiency_at_max = base_efficiency * (1 - target_drop)
+    # This gives us the 'b' parameter
+    b = (a * target_eff_drop) / max_spend
+
+    return a, b
+
+
+def generate_channel_benchmarks(config: dict) -> list[dict]:
+    """Generate benchmarks for all channels."""
+    random.seed(config["synth_data"]["random_seed"])
+
+    benchmarks = []
+    for ch in config["channels"]:
+        metrics = sample_channel_metrics_for_channel(ch["name"], config)
+        a, b = derive_quad_params(
+            metrics["cpc"], metrics["ctr"], metrics["cvr"], ch["max_spend"]
+        )
+
+        benchmarks.append(
+            {
+                "channel": ch["name"],
+                "cpc": metrics["cpc"],
+                "ctr": metrics["ctr"],
+                "cvr": metrics["cvr"],
+                "min_spend": ch["min_spend"],
+                "max_spend": ch["max_spend"],
+                "curve_a": a,
+                "curve_b": b,
+            }
+        )
+
+    return benchmarks
+
+
+def write_benchmarks_csv(benchmarks: list[dict], output_path: str):
+    """Write channel benchmarks to CSV."""
+    with open(output_path, "w", newline="") as f:
+        if benchmarks:
+            writer = csv.DictWriter(f, fieldnames=benchmarks[0].keys())
+            writer.writeheader()
+            writer.writerows(benchmarks)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,8 +21,8 @@ def sample_config():
     return {
         "budget": {"total": 50000.0, "currency": "USD"},
         "channels": [
-            {"name": "Google", "min_spend": 5000.0, "max_spend": 20000.0},
-            {"name": "Meta", "min_spend": 3000.0, "max_spend": 15000.0},
+            {"name": "google", "min_spend": 5000.0, "max_spend": 20000.0},
+            {"name": "meta", "min_spend": 3000.0, "max_spend": 15000.0},
         ],
         "synth_data": {"random_seed": 42, "cpc_range": [0.5, 3.0]},
         "optimization": {"solver": "scipy_minimize"},
@@ -52,11 +52,11 @@ def test_missing_file_fails():
 def test_helper_functions(sample_config):
     """Helper functions extract the right stuff."""
     names = get_channel_names(sample_config)
-    assert names == ["Google", "Meta"]
+    assert names == ["google", "meta"]
 
     constraints = get_channel_constraints(sample_config)
-    assert "Google" in constraints
-    assert constraints["Google"]["max_spend"] == 20000.0
+    assert "google" in constraints
+    assert constraints["google"]["max_spend"] == 20000.0
 
     budget = get_total_budget(sample_config)
     assert budget == 50000.0

--- a/tests/test_synth_contract.py
+++ b/tests/test_synth_contract.py
@@ -1,0 +1,131 @@
+"""Test synthetic data generation meets contract requirements."""
+
+import tempfile
+import csv
+from pathlib import Path
+
+from src.config.load import load_config
+from src.data.synth import (
+    generate_channel_benchmarks,
+    write_benchmarks_csv,
+    derive_quad_params,
+    sample_base_metrics,
+)
+
+
+def test_generate_benchmarks_basic():
+    """Basic benchmarks generation works."""
+    config = load_config("src/config/default.yaml")
+
+    benchmarks = generate_channel_benchmarks(config)
+
+    # Should have one benchmark per channel
+    assert len(benchmarks) == len(config["channels"])
+
+    # Check structure
+    required_fields = [
+        "channel",
+        "cpc",
+        "ctr",
+        "cvr",
+        "min_spend",
+        "max_spend",
+        "curve_a",
+        "curve_b",
+    ]
+    for bench in benchmarks:
+        for field in required_fields:
+            assert field in bench
+
+
+def test_deterministic_with_seed():
+    """Same seed produces same results."""
+    config = load_config("src/config/default.yaml")
+
+    benchmarks1 = generate_channel_benchmarks(config)
+    benchmarks2 = generate_channel_benchmarks(config)
+
+    # Should be identical (same seed)
+    assert benchmarks1 == benchmarks2
+
+
+def test_quadratic_params_make_sense():
+    """Quadratic parameters are mathematically sound."""
+    config = load_config("src/config/default.yaml")
+    benchmarks = generate_channel_benchmarks(config)
+
+    for bench in benchmarks:
+        a, b = bench["curve_a"], bench["curve_b"]
+        max_spend = bench["max_spend"]
+
+        # Both coefficients should be positive
+        assert a > 0, f"{bench['channel']}: a must be > 0"
+        assert b > 0, f"{bench['channel']}: b must be > 0"
+
+        # ROI at max spend should be positive but small
+        roi_at_max = a - 2 * b * max_spend
+        assert roi_at_max > 0, f"{bench['channel']}: ROI at max spend must be positive"
+        assert roi_at_max < a, f"{bench['channel']}: ROI should decrease with spend"
+
+
+def test_metric_ranges_reasonable():
+    """Generated metrics fall within reasonable ranges."""
+    config = load_config("src/config/default.yaml")
+    benchmarks = generate_channel_benchmarks(config)
+
+    for bench in benchmarks:
+        # Should be within or close to config ranges (allowing for channel multipliers)
+        assert 0.1 <= bench["cpc"] <= 10.0, f"CPC out of range: {bench['cpc']}"
+        assert 0.001 <= bench["ctr"] <= 0.20, f"CTR out of range: {bench['ctr']}"
+        assert 0.001 <= bench["cvr"] <= 0.20, f"CVR out of range: {bench['cvr']}"
+
+
+def test_csv_output_works():
+    """CSV output has correct structure."""
+    config = load_config("src/config/default.yaml")
+    benchmarks = generate_channel_benchmarks(config)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        write_benchmarks_csv(benchmarks, f.name)
+
+        # Read it back and verify
+        with open(f.name, "r") as rf:
+            reader = csv.DictReader(rf)
+            rows = list(reader)
+
+            assert len(rows) == len(benchmarks)
+            assert rows[0].keys() == benchmarks[0].keys()
+
+        Path(f.name).unlink()
+
+
+def test_base_metrics_sampling():
+    """Base metrics sampling works correctly."""
+    config = load_config("src/config/default.yaml")
+
+    metrics = sample_base_metrics(config)
+
+    # Should have right structure
+    assert set(metrics.keys()) == {"cpc", "ctr", "cvr"}
+
+    # Should be within config ranges
+    ranges = config["synth_data"]
+    assert ranges["cpc_range"][0] <= metrics["cpc"] <= ranges["cpc_range"][1]
+    assert ranges["ctr_range"][0] <= metrics["ctr"] <= ranges["ctr_range"][1]
+    assert ranges["cvr_range"][0] <= metrics["cvr"] <= ranges["cvr_range"][1]
+
+
+def test_quad_params_derivation():
+    """Quadratic parameter derivation is mathematically correct."""
+    cpc, ctr, cvr, max_spend = 2.0, 0.03, 0.04, 10000
+
+    a, b = derive_quad_params(cpc, ctr, cvr, max_spend)
+
+    # a should equal funnel efficiency
+    expected_a = (ctr * cvr) / cpc
+    assert abs(a - expected_a) < 1e-10
+
+    # At max spend, efficiency should drop by target percentage (30%)
+    efficiency_at_max = a - b * max_spend
+    efficiency_drop = 1 - (efficiency_at_max / a)
+    assert abs(efficiency_drop - 0.3) < 1e-10  # Should be 30%


### PR DESCRIPTION
This PR adds a way to generate synthetic channel data, wires it up to the CLI, and makes sure channel names are consistent across the project. It also drops in contract tests to keep the data generator honest. Variety of minor commentary changes and small simplifications included.

## Changes

### Synthetic data + CLI
- New `src/data/synth.py` that spits out synthetic-but-reasonable channel benchmarks (CPC/CTR/CVR plus quadratic diminishing returns) and writes them to a CSV.  
- New `src/cli.py` with a `synth` command so I can generate that data from the terminal, with flags for config + output path.

### Tests
- Added `tests/test_synth_contract.py` to check that the generator is:  
  - deterministic with a fixed seed  
  - producing values in the right ranges  
  - mathematically consistent (ROI fades correctly)  
  - actually writing a CSV that looks right

### Config + naming
- Updated `src/config/default.yaml` and tests to use lowercase channel names (`google`, `meta`, etc.) so everything lines up between config, generator, and loader.  

### Docs + misc
- Added CI and Python version badges to the README for quick repo credibility.  
- Tweaked a Makefile comment for clarity.
