### PR TITLE
feat: add quadratic spend curve model + tests

### DIFF
--- a/src/config/default.yaml
+++ b/src/config/default.yaml
@@ -26,7 +26,7 @@ channels:
     min_spend: 2000.0
     max_spend: 25000.0
 
-  - name: "x"
+  - name: "x" # formerly Twitter
     min_spend: 1000.0
     max_spend: 15000.0
 

--- a/src/features/curves.py
+++ b/src/features/curves.py
@@ -1,0 +1,58 @@
+"""
+Mathematical functions for modeling marketing spend curves.
+
+Implements quadratic saturation curves to capture diminishing returns
+in digital advertising performance.
+"""
+
+
+def quad_conversions(spend: float, a: float, b: float) -> float:
+    """
+    Conversions as a quadratic function of spend.
+
+    Business logic:
+        This models the diminishing returns / saturation concept: after a certain point,
+        each additional dollar spent yields progressively fewer conversions.
+
+    Math:
+        `y = a * spend - b * spend^2`
+        Where:
+        - 'y' is the total conversions at a level of spend
+        - 'a' is the initial conversions per dollar (≈ CVR * CTR / CPC)
+        - 'b' is the curvature that flattens performance as spend grows
+
+    This is intentionally simple for V1: concave, monotone-increasing in our operating
+    range, and easy to optimize with quadratic programming. Very likely that we'll build
+    upon this in future versions with more advanced logic.
+    """
+    return (a * spend) - (b * spend**2)
+
+
+def quad_grad(spend: float, a: float, b: float) -> float:
+    """
+    Marginal ROI (gradient) at a given spend level.
+
+    Business logic:
+        Shows the incremental conversions per additional dollar spent.
+        Decreases as spend increases (diminishing returns).
+
+    Math:
+        `dy/dx = a - 2 * b * spend`
+        First derivative of the quadratic curve.
+    """
+    return a - (2 * b * spend)
+
+
+def validate_curve_params(a, b):
+    """Check if curve params make business sense."""
+    # Need positive coefficients for realistic diminishing returns
+    return a > 0 and b > 0
+
+
+def conversions_at_spend_levels(spend_levels: list, a: float, b: float) -> list[float]:
+    """Batch calculate conversions for multiple spend levels."""
+    if not validate_curve_params(a, b):
+        raise ValueError("Invalid curve parameters")
+
+    # Useful for plotting and analysis later
+    return [quad_conversions(spend, a, b) for spend in spend_levels]

--- a/tests/test_curves_quad.py
+++ b/tests/test_curves_quad.py
@@ -1,0 +1,112 @@
+"""Tests the quadratic curve math functions from curves.py."""
+
+from src.features.curves import (
+    quad_conversions,
+    quad_grad,
+    validate_curve_params,
+    conversions_at_spend_levels,
+)
+
+
+def test_quad_conversions_basic():
+    """Tests that the basic quadratic conversion calculation works."""
+    a, b = 0.001, 1e-8
+    spend = 10000
+
+    result = quad_conversions(spend, a, b)
+
+    # Should be positive and reasonable
+    assert result > 0
+    # Should equal a*spend - b*spend^2
+    expected = a * spend - b * spend**2
+    assert abs(result - expected) < 1e-10  # Floating point tolerance
+
+
+def test_quad_grad_decreasing():
+    """Tests that marginal ROI decreases with higher spend."""
+    a, b = 0.001, 1e-8
+    spend1, spend2 = 5000, 10000
+
+    roi1 = quad_grad(spend1, a, b)
+    roi2 = quad_grad(spend2, a, b)
+
+    # ROI should decrease as spend increases
+    assert roi1 > roi2
+    assert roi1 > 0
+    assert roi2 > 0
+
+
+def test_curve_properties():
+    """Tests that the curve has correct mathematical properties (concave, monotone)."""
+    a, b = 0.001, 1e-8
+    spend_levels = [1000, 5000, 10000, 15000]
+
+    conversions = [quad_conversions(s, a, b) for s in spend_levels]
+    rois = [quad_grad(s, a, b) for s in spend_levels]
+
+    # Conversions should be monotone increasing
+    for i in range(1, len(conversions)):
+        assert conversions[i] > conversions[i - 1]
+
+    # ROI should be monotone decreasing
+    for i in range(1, len(rois)):
+        assert rois[i] < rois[i - 1]
+
+    # All ROI should be positive in reasonable range
+    assert all(roi > 0 for roi in rois)
+
+
+def test_realistic_parameters():
+    """Curves should work with realistic marketing parameters."""
+    # Use parameters similar to what synth.py generates
+    a = 0.0008  # Reasonable efficiency
+    b = 1e-8  # Small curvature
+    max_spend = 25000
+
+    # Should have positive ROI at max spend
+    roi_at_max = quad_grad(max_spend, a, b)
+    assert roi_at_max > 0
+
+    # Total conversions should be reasonable
+    total_conversions = quad_conversions(max_spend, a, b)
+    assert total_conversions > 0
+    assert total_conversions < max_spend  # Sanity check
+
+
+def test_validate_curve_params():
+    """Parameter validation works correctly."""
+    # Valid params
+    assert validate_curve_params(0.001, 1e-8) is True
+
+    # Invalid params
+    assert validate_curve_params(-0.001, 1e-8) is False  # Negative a
+    assert validate_curve_params(0.001, -1e-8) is False  # Negative b
+    assert validate_curve_params(0, 1e-8) is False  # Zero a
+    assert validate_curve_params(0.001, 0) is False  # Zero b
+
+
+def test_batch_conversions():
+    """Batch conversion calculation works."""
+    a, b = 0.001, 1e-8
+    spend_levels = [1000, 5000, 10000]
+
+    results = conversions_at_spend_levels(spend_levels, a, b)
+
+    assert len(results) == len(spend_levels)
+    assert all(r > 0 for r in results)
+
+    # Should match individual calculations
+    for spend, result in zip(spend_levels, results):
+        expected = quad_conversions(spend, a, b)
+        assert abs(result - expected) < 1e-10
+
+
+def test_batch_conversions_invalid_params():
+    """Batch conversion fails with invalid parameters."""
+    spend_levels = [1000, 5000]
+
+    try:
+        conversions_at_spend_levels(spend_levels, -0.001, 1e-8)
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass  # Expected

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,0 @@
-def test_placeholder():
-    """Placeholder test to make 'make test' work."""
-    assert True


### PR DESCRIPTION
This PR adds the math layer for modeling diminishing returns, includes solid unit tests for it, and does a bit of cleanup on config/tests. The big piece here is a quadratic curve that captures how conversions taper off as spend goes up.

## Changes

### Quadratic curve modeling
- New `src/features/curves.py` with functions for quadratic conversions (`quad_conversions`), marginal ROI (`quad_grad`), parameter checks, and a helper for batch calculations.

### Tests + validation
- Added `tests/test_curves_quad.py` to cover the math: conversions, gradients, and parameter sanity checks.  
- Dropped the old `tests/test_placeholder.py` since we now have real tests.

### Config cleanup
- Updated `src/config/default.yaml` to clarify that the `"x"` channel refers to Twitter (now X) so the config is easier to read.
